### PR TITLE
SCADADiagram.remapDiagram causes error of missing fromPort, toPort

### DIFF
--- a/modules/scada.js
+++ b/modules/scada.js
@@ -81,7 +81,7 @@ export class SCADASheet {
 
     // Tạo Diagram mới
     this.innitDiagram({
-      model: this.sheetModels?.[sheetName]?.model || {},
+      model: this.sheetModels?.[sheetName]?.model || null,
       position: this.sheetModels?.[sheetName]?.position || "0 0",
     });
 

--- a/modules/scadaDiagram.js
+++ b/modules/scadaDiagram.js
@@ -178,7 +178,6 @@ export class SCADADiagram {
     if (this.diagram) {
       this.diagram.div = null; // Bắt buộc để GoJS hủy liên kết với div
       this.diagram.clear(); // Giải phóng tài nguyên
-      this.diagram = null;
     }
     this.jsonModel = model;
     this.initDiagram();

--- a/pages/map-template/mapTemplate.js
+++ b/pages/map-template/mapTemplate.js
@@ -213,10 +213,3 @@ const sheetManager = new SCADASheet({
 
 window.exportAllJson = () => sheetManager.exportAllJson();
 window.importJson = (e) => sheetManager.importJson(e);
-
-const diagram = sheetManager.diagram;
-
-diagram.model = new go.GraphLinksModel({
-  linkFromPortIdProperty: "fromPort", // required information:
-  linkToPortIdProperty: "toPort", // identifies data property names
-});


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/44475bcf-7b9e-4209-bde4-a48f236b3866)

![image](https://github.com/user-attachments/assets/f3bd7121-bf43-4fe1-a3c8-e67aeec15ae5)
